### PR TITLE
33_Terraformを使ったインフラのコード化と自動化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Terraform local state
+*.tfstate
+*.tfstate.*
+terraform.tfstate
+terraform.tfstate.backup
+
+# Terraform working dir
+.terraform/
+
+# Sensitive vars
+*.tfvars
+terraform.tfvars

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.12.0"
+  constraints = ">= 6.12.0"
+  hashes = [
+    "h1:gyxS4zzWCf8UCQBMUD8nP4WDsi9xSzQmVs3a8yOe0Nc=",
+    "zh:054bcbf13c6ac9ddd2247876f82f9b56493e2f71d8c88baeec142386a395165d",
+    "zh:195489f16ad5621db2cec80be997d33060462a3b8d442c890bef3eceba34fa4d",
+    "zh:3461ef14904ab7de246296e44d24c042f3190e6bead3d7ce1d9fda63dcb0f047",
+    "zh:44517a0035996431e4127f45db5a84f53ce80730eae35629eda3101709df1e5c",
+    "zh:4b0374abaa6b9a9debed563380cc944873e4f30771dd1da7b9e812a49bf485e3",
+    "zh:531468b99465bd98a89a4ce2f1a30168dfadf6edb57f7836df8a977a2c4f9804",
+    "zh:6a95ed7b4852174aa748d3412bff3d45e4d7420d12659f981c3d9f4a1a59a35f",
+    "zh:88c2d21af1e64eed4a13dbb85590c66a519f3ecc54b72875d4bb6326f3ef84e7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a8b648470bb5df098e56b1ec5c6a39e0bbb7b496b23a19ea9f494bf48d4a122a",
+    "zh:b23fb13efdb527677db546bc92aeb2bdf64ff3f480188841f2bfdfa7d3d907c1",
+    "zh:be5858a1951ae5f5a9c388949c3e3c66a3375f684fb79b06b1d1db7a9703b18e",
+    "zh:c368e03a7c922493daf4c7348faafc45f455225815ef218b5491c46cea5f76b7",
+    "zh:e31e75d5d19b8ac08aa01be7e78207966e1faa3b82ed9fe3acfdc2d806be924c",
+    "zh:ea84182343b5fd9252a6fae41e844eed4fdc3311473a753b09f06e49ec0e7853",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+文言例
+terraform.tfvars の作成
+
+cp terraform.tfvars.example 
+terraform.tfvars
+
+terraform.tfvarsに実値を記入
+（機密情報を含むためリポジトリに追加しないでください）
+
+必要変数（例）
+
+db_username: DB のユーザー名（必須）
+db_password: DB のパスワード（必須, sensitive）
+key_name: EC2 用キーペア名（必須）
+notification_email: 通知先メール（必須）
+my_ip: SSH 許可 IP（例: x.x.x.x/32）
+
+注意事項
+
+terraform.tfvars は機密情報を含むのでコミットしないでください。terraform.tfvars.example を用意しています。
+SNS のメールは受信側で Confirm が必要です。Confirmed 状態を確認してください。
+誤って機密をコミットした場合は直ちに該当シークレットをローテーションし、履歴のクリーンアップを行ってください（担当: とおる）。

--- a/backend.tf
+++ b/backend.tf
@@ -1,7 +1,9 @@
 terraform {
   backend "s3" {
-    bucket = "terraform-backend-20250904" # ← 作成済みS3バケット名を記入
-    key    = "terraform.tfstate"
-    region = "ap-northeast-1"
+    bucket         = "terraform-backend-20250904" # ← 作成済みS3バケット名を記入
+    key            = "terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform-locks" # 追加
+    encrypt        = true
   }
 }

--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-backend-20250904" # ← 作成済みS3バケット名を記入
+    key    = "terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,54 @@
+module "vpc" {
+  source = "./modules/vpc"
+}
+
+module "ec2" {
+  source           = "./modules/ec2"
+  vpc_id           = module.vpc.aws_vpc_id
+  public_subnet_id = module.vpc.public_subnet1_id
+  key_name         = "toru-aws-key" # 作成済みキーペア名
+}
+
+output "ec2_public_ip" {
+  value = module.ec2.ec2_public_ip
+}
+
+output "ec2_id" {
+  value = module.ec2.ec2_id
+}
+
+module "rds" {
+  source                = "./modules/rds"
+  vpc_id                = module.vpc.aws_vpc_id
+  private_subnet_ids    = module.vpc.private_subnet_ids
+  ec2_security_group_id = module.ec2.ec2_sg_id
+
+  # terraform.tfvars に書いた値を.rds.variables.tfに渡す
+  db_username = var.db_username
+  db_password = var.db_password
+}
+
+module "alb" {
+  source            = "./modules/alb"
+  vpc_id            = module.vpc.aws_vpc_id
+  public_subnet_ids = [module.vpc.public_subnet1_id, module.vpc.public_subnet2_id]
+  ec2_id            = module.ec2.ec2_id
+}
+
+module "cloudwatch" {
+  source             = "./modules/cloudwatch"
+  ec2_id             = module.ec2.ec2_id
+  notification_email = "29oishi4@gmail.com" # ←あなたのメールアドレス
+}
+
+module "waf" {
+  source         = "./modules/waf"
+  alb_arn        = module.alb.alb_arn # ← ここを修正
+  log_group_name = "/aws-waf-logs/aws-study"
+}
+
+# WAF と ALB を関連付けるリソース
+resource "aws_wafv2_web_acl_association" "alb_waf" {
+  resource_arn = module.alb.alb_arn       # ALBモジュールが出力した値
+  web_acl_arn  = module.waf.web_acl_arn   # WAFモジュールが出力した値
+}

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,8 @@ module "ec2" {
   source           = "./modules/ec2"
   vpc_id           = module.vpc.aws_vpc_id
   public_subnet_id = module.vpc.public_subnet1_id
-  key_name         = "toru-aws-key" # 作成済みキーペア名
+  key_name         = var.key_name # 作成済みキーペア名
+  my_ip            = var.my_ip
 }
 
 output "ec2_public_ip" {
@@ -38,7 +39,7 @@ module "alb" {
 module "cloudwatch" {
   source             = "./modules/cloudwatch"
   ec2_id             = module.ec2.ec2_id
-  notification_email = "29oishi4@gmail.com" # ←あなたのメールアドレス
+  notification_email = var.notification_email #ハードコードから変数に変更
 }
 
 module "waf" {
@@ -46,9 +47,8 @@ module "waf" {
   alb_arn        = module.alb.alb_arn # ← ここを修正
   log_group_name = "/aws-waf-logs/aws-study"
 }
-
 # WAF と ALB を関連付けるリソース
 resource "aws_wafv2_web_acl_association" "alb_waf" {
-  resource_arn = module.alb.alb_arn       # ALBモジュールが出力した値
-  web_acl_arn  = module.waf.web_acl_arn   # WAFモジュールが出力した値
+  resource_arn = module.alb.alb_arn     # ALBモジュールが出力した値
+  web_acl_arn  = module.waf.web_acl_arn # WAFモジュールが出力した値
 }

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -1,0 +1,77 @@
+# ALB用セキュリティグループ
+resource "aws_security_group" "alb_sg" {
+  name        = "aws-study-alb-sg"
+  description = "Allow HTTP traffic from internet"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "aws-study-alb-sg"
+  }
+}
+
+# Application Load Balancer
+resource "aws_lb" "aws-study-alb" {
+  name               = "aws-study-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb_sg.id]
+  subnets            = var.public_subnet_ids
+
+  tags = {
+    Name = "aws-study-alb"
+  }
+}
+
+# ターゲットグループ
+resource "aws_lb_target_group" "aws-study-tg" {
+  name     = "aws-study-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    path                = "/"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    timeout             = 5
+  }
+
+  tags = {
+    Name = "aws-study-tg"
+  }
+}
+
+# リスナー
+resource "aws_lb_listener" "aws-study-listener" {
+  load_balancer_arn = aws_lb.aws-study-alb.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.aws-study-tg.arn
+  }
+}
+
+resource "aws_lb_target_group_attachment" "ec2_attach" {
+  target_group_arn = aws_lb_target_group.aws-study-tg.arn
+  target_id        = var.ec2_id   # ルートから module.alb に渡す
+  port             = 80
+}

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -39,19 +39,19 @@ resource "aws_lb" "aws-study-alb" {
 # ターゲットグループ
 resource "aws_lb_target_group" "aws-study-tg" {
   name     = "aws-study-tg"
-  port     = 80
+  port     = 8080
   protocol = "HTTP"
   vpc_id   = var.vpc_id
 
-  health_check {
-    path                = "/"
-    protocol            = "HTTP"
-    matcher             = "200"
-    interval            = 30
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    timeout             = 5
-  }
+health_check {
+  path     = "/"
+  protocol = "HTTP"
+  matcher  = "200-299"  #Provider互換の為、範囲のみ変更。ブロック形式に無し
+  interval            = 30
+  healthy_threshold   = 3
+  unhealthy_threshold = 3
+  timeout             = 5
+}
 
   tags = {
     Name = "aws-study-tg"
@@ -73,5 +73,5 @@ resource "aws_lb_listener" "aws-study-listener" {
 resource "aws_lb_target_group_attachment" "ec2_attach" {
   target_group_arn = aws_lb_target_group.aws-study-tg.arn
   target_id        = var.ec2_id   # ルートから module.alb に渡す
-  port             = 80
+  port             = 8080
 }

--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -1,0 +1,19 @@
+output "alb_dns_name" {
+  description = "DNS name of the ALB"
+  value       = aws_lb.aws-study-alb.dns_name
+}
+
+output "alb_sg_id" {
+  description = "ALB Security Group ID"
+  value       = aws_security_group.alb_sg.id
+}
+
+output "alb_target_group_arn" {
+  description = "Target Group ARN"
+  value       = aws_lb_target_group.aws-study-tg.arn
+}
+
+output "alb_arn" {
+  description = "ARN of the ALB"
+  value       = aws_lb.aws-study-alb.arn
+}

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -1,0 +1,14 @@
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "List of public subnet IDs for ALB"
+  type        = list(string)
+}
+
+variable "ec2_id" {
+  description = "EC2 instance ID to attach to Target Group"
+  type        = string
+}

--- a/modules/cloudwatch/main.tf
+++ b/modules/cloudwatch/main.tf
@@ -1,0 +1,28 @@
+# EC2 CPU 使用率 0.1% 超でアラーム
+resource "aws_cloudwatch_metric_alarm" "ec2_high_cpu" {
+  alarm_name          = "EC2HighCPUAlarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 0.1
+  alarm_description   = "EC2 CPU 使用率が 0.1% を超えた場合に通知"
+  dimensions = {
+    InstanceId = var.ec2_id
+  }
+alarm_actions = [aws_sns_topic.cpu_alarm_topic.arn]
+}
+
+# SNS トピック作成
+resource "aws_sns_topic" "cpu_alarm_topic" {
+  name = "EC2HighCPUAlarmTopic"
+}
+
+# SNS サブスクリプション（あなたのメールアドレスに直接送信）
+resource "aws_sns_topic_subscription" "cpu_alarm_sub" {
+  topic_arn = aws_sns_topic.cpu_alarm_topic.arn
+  protocol  = "email"
+  endpoint  = "29oishi4@gmail.com"  # ←ここに自分のメール
+}

--- a/modules/cloudwatch/main.tf
+++ b/modules/cloudwatch/main.tf
@@ -1,4 +1,4 @@
-# EC2 CPU 使用率 0.1% 超でアラーム
+# EC2 CPU 使用率 ７０% 超でアラーム
 resource "aws_cloudwatch_metric_alarm" "ec2_high_cpu" {
   alarm_name          = "EC2HighCPUAlarm"
   comparison_operator = "GreaterThanThreshold"
@@ -7,12 +7,12 @@ resource "aws_cloudwatch_metric_alarm" "ec2_high_cpu" {
   namespace           = "AWS/EC2"
   period              = 300
   statistic           = "Average"
-  threshold           = 0.1
-  alarm_description   = "EC2 CPU 使用率が 0.1% を超えた場合に通知"
+  threshold           = 70
+  alarm_description   = "実運用を意識して70％に変更"
   dimensions = {
     InstanceId = var.ec2_id
   }
-alarm_actions = [aws_sns_topic.cpu_alarm_topic.arn]
+  alarm_actions = [aws_sns_topic.cpu_alarm_topic.arn]
 }
 
 # SNS トピック作成
@@ -24,5 +24,5 @@ resource "aws_sns_topic" "cpu_alarm_topic" {
 resource "aws_sns_topic_subscription" "cpu_alarm_sub" {
   topic_arn = aws_sns_topic.cpu_alarm_topic.arn
   protocol  = "email"
-  endpoint  = "29oishi4@gmail.com"  # ←ここに自分のメール
+  endpoint = var.notification_email #ハードコードから変数に変更
 }

--- a/modules/cloudwatch/outputs.tf
+++ b/modules/cloudwatch/outputs.tf
@@ -1,0 +1,4 @@
+output "ec2_high_cpu_alarm" {
+  description = "CloudWatch Alarm for EC2 High CPU"
+  value       = aws_cloudwatch_metric_alarm.ec2_high_cpu.id
+}

--- a/modules/cloudwatch/variables.tf
+++ b/modules/cloudwatch/variables.tf
@@ -1,0 +1,9 @@
+variable "ec2_id" {
+  description = "EC2 instance ID to monitor"
+  type        = string
+}
+
+variable "notification_email" {
+  description = "アラート通知先メールアドレス"
+  type        = string
+}

--- a/modules/cloudwatch/variables.tf
+++ b/modules/cloudwatch/variables.tf
@@ -6,4 +6,5 @@ variable "ec2_id" {
 variable "notification_email" {
   description = "アラート通知先メールアドレス"
   type        = string
+  sensitive   = true
 }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -19,7 +19,7 @@ resource "aws_security_group" "ec2_sg" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["219.104.129.44/32"] # 自分のIPからSSH
+    cidr_blocks = [var.my_ip]   #ハードコードから変数に変更
   }
 
   ingress {

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -1,0 +1,63 @@
+# Amazon Linux 2023 最新 AMI を自動取得
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023*-kernel-6.1-x86_64"] # 通常版
+  }
+}
+
+# EC2用セキュリティグループ
+resource "aws_security_group" "ec2_sg" {
+  name        = "main-ec2-sg"
+  description = "Allow SSH and HTTP access"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["219.104.129.44/32"] # 自分のIPからSSH
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]  # CloudFormationコードに合わせる
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "main-ec2-sg"
+  }
+}
+
+# EC2 インスタンス
+resource "aws_instance" "main_ec2" {
+  ami                         = data.aws_ami.amazon_linux.id
+  instance_type               = "t2.micro"
+  subnet_id                   = var.public_subnet_id
+  vpc_security_group_ids      = [aws_security_group.ec2_sg.id]
+  associate_public_ip_address = true
+  key_name                    = var.key_name   # ← 変数で受け取る
+
+  tags = {
+    Name = "main-ec2"
+  }
+}

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -1,0 +1,13 @@
+output "ec2_public_ip" {
+  value = aws_instance.main_ec2.public_ip
+}
+
+output "ec2_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.main_ec2.id
+}
+
+# RDS用にEC2のSGを渡す
+output "ec2_sg_id" {
+  value = aws_security_group.ec2_sg.id
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,0 +1,14 @@
+variable "vpc_id" {
+  description = "作成済みVPCのID"
+  type        = string
+}
+
+variable "public_subnet_id" {
+  description = "EC2を配置するパブリックサブネットID"
+  type        = string
+}
+
+variable "key_name" {
+  description = "作成済みSSHキーペア名"
+  type        = string
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -12,3 +12,8 @@ variable "key_name" {
   description = "作成済みSSHキーペア名"
   type        = string
 }
+
+variable "my_ip" {
+  description = "管理者アクセス用固定IP"
+  type        = string
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,0 +1,56 @@
+# RDS 用セキュリティグループ
+resource "aws_security_group" "rds_sg" {
+  name        = "aws-study-rds-sg"
+  description = "Allow EC2 access to RDS"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port                = 3306
+    to_port                  = 3306
+    protocol                 = "tcp"
+    security_groups          = [var.ec2_security_group_id]
+    description              = "Allow EC2 SG access to RDS"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "aws-study-rds-sg"
+  }
+}
+
+# RDS Subnet Group
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name       = "aws-study-rds-subnetgroup"
+  subnet_ids = var.private_subnet_ids
+  description = "Subnet group for RDS"
+
+  tags = {
+    Name = "aws-study-rds-subnetgroup"
+  }
+}
+
+# RDS インスタンス
+resource "aws_db_instance" "rds_instance" {
+  identifier              = "aws-study-rds"
+  engine                  = "mysql"
+  engine_version          = "8.0.39"
+  instance_class          = "db.t4g.micro"
+  allocated_storage       = 20
+  db_name                 = "awsstudy"
+  username                = var.db_username
+  password                = var.db_password
+  db_subnet_group_name    = aws_db_subnet_group.rds_subnet_group.name
+  vpc_security_group_ids  = [aws_security_group.rds_sg.id]
+  skip_final_snapshot     = true
+  publicly_accessible     = false
+
+  tags = {
+    Name = "aws-study-rds"
+  }
+}

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,14 @@
+output "rds_endpoint" {
+  description = "RDS endpoint address"
+  value       = aws_db_instance.rds_instance.endpoint
+}
+
+output "rds_id" {
+  description = "RDS instance ID"
+  value       = aws_db_instance.rds_instance.id
+}
+
+output "rds_sg_id" {
+  description = "RDS Security Group ID"
+  value       = aws_security_group.rds_sg.id
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,25 @@
+variable "vpc_id" {
+  description = "VPC ID where RDS will be deployed"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs for RDS subnet group"
+  type        = list(string)
+}
+
+variable "ec2_security_group_id" {
+  description = "Security Group ID of EC2 instances allowed to access RDS"
+  type        = string
+}
+
+variable "db_username" {
+  description = "Master username for RDS"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Master password for RDS"
+  type        = string
+  sensitive   = true
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,111 @@
+# modules/vpc/main.tf
+
+# VPC
+resource "aws_vpc" "aws_study_vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "aws-study-vpc"
+  }
+}
+
+# パブリックサブネット
+resource "aws_subnet" "MyPublicSubnet1" {
+  vpc_id                  = aws_vpc.aws_study_vpc.id
+  cidr_block              = "10.0.1.0/24"
+  map_public_ip_on_launch = true
+  availability_zone       = "ap-northeast-1a"
+
+  tags = {
+    Name = "MyPublicSubnet1"
+  }
+}
+
+resource "aws_subnet" "MyPublicSubnet2" {
+  vpc_id                  = aws_vpc.aws_study_vpc.id
+  cidr_block              = "10.0.3.0/24"
+  map_public_ip_on_launch = true
+  availability_zone       = "ap-northeast-1c"
+  
+  tags = {
+    Name = "MyPublicSubnet2"
+  }
+}
+
+# プライベートサブネット
+resource "aws_subnet" "PrivateSubnet1" {
+  vpc_id            = aws_vpc.aws_study_vpc.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone       = "ap-northeast-1a"
+
+  tags = {
+    Name = "PrivateSubnet1"
+  }
+}
+
+resource "aws_subnet" "PrivateSubnet2" {
+  vpc_id            = aws_vpc.aws_study_vpc.id
+  cidr_block        = "10.0.4.0/24"
+  availability_zone       = "ap-northeast-1c"
+
+  tags = {
+    Name = "PrivateSubnet2"
+  }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "aws_study_igw" {
+  vpc_id = aws_vpc.aws_study_vpc.id
+
+  tags = {
+    Name = "aws-study-igw"
+  }
+}
+
+# パブリックルートテーブル
+resource "aws_route_table" "MyPublicRouteTable" {
+  vpc_id = aws_vpc.aws_study_vpc.id
+
+  tags = {
+    Name = "MyPublicRouteTable"
+  }
+}
+
+# プライベートルートテーブル
+resource "aws_route_table" "MyPrivateRouteTable" {
+  vpc_id = aws_vpc.aws_study_vpc.id
+
+  tags = {
+    Name = "MyPrivateRouteTable"
+  }
+}
+
+# パブリックルート
+resource "aws_route" "MyPublicRoute" {
+  route_table_id         = aws_route_table.MyPublicRouteTable.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.aws_study_igw.id
+}
+
+# サブネットとルートテーブルの関連付け
+resource "aws_route_table_association" "MyPublicSubnet1RouteTableAssociation" {
+  subnet_id      = aws_subnet.MyPublicSubnet1.id
+  route_table_id = aws_route_table.MyPublicRouteTable.id
+}
+
+resource "aws_route_table_association" "MyPublicSubnet2RouteTableAssociation" {
+  subnet_id      = aws_subnet.MyPublicSubnet2.id
+  route_table_id = aws_route_table.MyPublicRouteTable.id
+}
+
+resource "aws_route_table_association" "PrivateSubnet1RouteTableAssociation" {
+  subnet_id      = aws_subnet.PrivateSubnet1.id
+  route_table_id = aws_route_table.MyPrivateRouteTable.id
+}
+
+resource "aws_route_table_association" "PrivateSubnet2RouteTableAssociation" {
+  subnet_id      = aws_subnet.PrivateSubnet2.id
+  route_table_id = aws_route_table.MyPrivateRouteTable.id
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,22 @@
+# VPC ID を外部モジュールに渡す
+output "aws_vpc_id" {
+  value = aws_vpc.aws_study_vpc.id
+}
+
+# パブリックサブネット1 の ID を外部に渡す
+output "public_subnet1_id" {
+  value = aws_subnet.MyPublicSubnet1.id
+}
+
+# パブリックサブネット2 の ID を外部に渡す
+output "public_subnet2_id" {
+  value = aws_subnet.MyPublicSubnet2.id
+}
+
+# プライベートサブネット ID（RDS用）
+output "private_subnet_ids" {
+  value = [
+    aws_subnet.PrivateSubnet1.id,
+    aws_subnet.PrivateSubnet2.id
+  ]
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,11 +1,12 @@
 # VPC ID を外部モジュールに渡す
 output "aws_vpc_id" {
-  value = aws_vpc.aws_study_vpc.id
+  value       = aws_vpc.aws_study_vpc.id
+  description = "作成されたVPCのID"
 }
 
 # パブリックサブネット1 の ID を外部に渡す
 output "public_subnet1_id" {
-  value = aws_subnet.MyPublicSubnet1.id
+  value       = aws_subnet.MyPublicSubnet1.id
 }
 
 # パブリックサブネット2 の ID を外部に渡す

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,23 @@
+variable "vpc_cidr" {
+  description = "VPCのCIDR"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "azs" {
+  description = "使用するAZ"
+  type        = list(string)
+  default     = ["ap-northeast-1a", "ap-northeast-1c"]
+}
+
+variable "public_subnets" {
+  description = "パブリックサブネットCIDRリスト"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnets" {
+  description = "プライベートサブネットCIDRリスト"
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24"]
+}

--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -1,0 +1,104 @@
+# CloudWatch Logs グループ作成
+resource "aws_cloudwatch_log_group" "waf" {
+  name              = "aws-waf-logs-aws-study" # スラッシュなし
+  retention_in_days = 7
+}
+
+# WAF ロギング用 IAM ロール
+resource "aws_iam_role" "waf_logging_role" {
+  name = "WAFLoggingRole_aws_study"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = { Service = "wafv2.amazonaws.com" }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# IAM ポリシー
+resource "aws_iam_role_policy" "waf_logging_policy_doc" {
+  name = "WAFLoggingToCloudWatch"
+  role = aws_iam_role.waf_logging_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# WAF WebACL
+resource "aws_wafv2_web_acl" "web_acl" {
+  name  = "aws_study_web_acl"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    sampled_requests_enabled   = true
+    metric_name                = "aws_study_web_acl"
+  }
+}
+
+# WAF ログ設定
+resource "aws_wafv2_web_acl_logging_configuration" "cloudwatch_logging" {
+  resource_arn = aws_wafv2_web_acl.web_acl.arn
+
+  log_destination_configs = [
+    aws_cloudwatch_log_group.waf.arn
+  ]
+
+  depends_on = [
+    aws_wafv2_web_acl.web_acl,
+    aws_cloudwatch_log_group.waf,
+    aws_iam_role.waf_logging_role,
+    aws_iam_role_policy.waf_logging_policy_doc
+  ]
+
+  # ログフィルター例
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      requirement = "MEETS_ANY"
+      behavior    = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+      condition {
+        action_condition {
+          action = "COUNT"
+        }
+      }
+    }
+  }
+
+  # ヘッダーのマスク例
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
+}

--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -31,13 +31,19 @@ resource "aws_iam_role_policy" "waf_logging_policy_doc" {
       {
         Effect = "Allow"
         Action = [
-          "logs:CreateLogGroup",
-          "logs:CreateLogStream",
-          "logs:PutLogEvents",
-          "logs:DescribeLogGroups",
-          "logs:DescribeLogStreams"
+          "logs:CreateLogStream",    # 追記: LogGroup 内のストリーム作成権限
+          "logs:PutLogEvents"       # 追記: LogGroup へのログ書き込み権限
         ]
-        Resource = "*"
+        #修正: Resource="*" を LogGroup のみに限定
+        Resource = "${aws_cloudwatch_log_group.waf.arn}:*"  # 追記: LogGroup 内すべてのストリーム
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogGroups",   # 追記: LogGroup 情報参照
+          "logs:DescribeLogStreams"   # 追記: ストリーム情報参照
+        ]
+        Resource = aws_cloudwatch_log_group.waf.arn  # 修正:LogGroup のみに限定
       }
     ]
   })

--- a/modules/waf/outputs.tf
+++ b/modules/waf/outputs.tf
@@ -1,0 +1,7 @@
+output "web_acl_arn" {
+  value = aws_wafv2_web_acl.web_acl.arn
+}
+
+output "cloudwatch_log_group_arn" {
+  value = aws_cloudwatch_log_group.waf.arn
+}

--- a/modules/waf/variables.tf
+++ b/modules/waf/variables.tf
@@ -1,0 +1,9 @@
+variable "alb_arn" {
+  type        = string
+  description = "ALBのARN"
+}
+
+variable "log_group_name" {
+  type        = string
+  description = "CloudWatch Logs"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,11 @@
+# VPC ID
+output "vpc_id" {
+  value       = module.vpc.aws_vpc_id
+  description = "作成された VPC の ID"
+}
+
+# ALB DNS 名
+output "alb_dns_name" {
+  value       = module.alb.alb_dns_name
+  description = "ALB の DNS 名"
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.12.0" # ← WAF Logging 用に必須
+    }
+  }
+}
+
+provider "aws" {
+  region  = "ap-northeast-1" # 東京リージョン
+  profile = "default"        # aws configure で設定したプロファイル
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,20 @@ variable "db_password" {
   type        = string
   sensitive   = true
 }
+
+# root/variables.tf に追加
+variable "key_name" {
+  description = "EC2で使用するSSHキーペア名"
+  type        = string
+}
+
+variable "notification_email" {
+  description = "アラーム通知用メールアドレス"
+  type        = string
+  sensitive   = true
+}
+
+variable "my_ip" {
+  description = "管理者アクセス用固定IP"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,10 @@
+variable "db_username" {
+  description = "RDS master username (root module)"
+  type        = string
+}
+
+variable "db_password" {
+  description = "RDS master password (root module)"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
# Terraform インフラ構築作業まとめ
<img width="1536" height="1024" alt="ChatGPT Image 2025年9月17日 22_27_04" src="https://github.com/user-attachments/assets/6cd1c685-1538-4575-90ca-634877878ec4" />

## 1. GitHub環境（Testブランチ）
- ブランチ: `test`
- リモートには `main` と `test` が存在
- 動作確認作業完了後にまとめてコミット・プッシュ済み

## 2.Terraform ファイル構成
.
├── backend.tf
├── main.tf
├── providers.tf
├── outputs.tf
├── variables.tf
├── modules/
│ ├── alb/
│ │ ├── main.tf
│ │ ├── outputs.tf
│ │ └── variables.tf
│ ├── cloudwatch/
│ │ ├── main.tf
│ │ ├── outputs.tf
│ │ └── variables.tf
│ ├── ec2/
│ │ ├── main.tf
│ │ ├── outputs.tf
│ │ └── variables.tf
│ ├── rds/
│ │ ├── main.tf
│ │ ├── outputs.tf
│ │ └── variables.tf
│ ├── vpc/
│ │ ├── main.tf
│ │ ├── outputs.tf
│ │ └── variables.tf
│ └── waf/
│ ├── main.tf
│ ├── outputs.tf
│ └── variables.tf
└── .gitignore

## 3. .gitignore 設定
- Terraform local state の共有NGとされるファイルを除外
また、terraform.tfstate は Git に含めず S3 バックエンドで管理
<img width="653" height="652" alt="スクリーンショット 2025-09-17 223813" src="https://github.com/user-attachments/assets/e73e0ac6-0745-4ffc-ad61-7c158cf5451f" />


*.tfstate
*.tfstate.*
terraform.tfstate
terraform.tfstate.backup
.terraform/
*.tfvars
terraform.tfvars

## 4.  実装内容
VPC
仮想ネットワークの作成
サブネット、ルートテーブル、インターネットゲートウェイなどを管理

ALB (Application Load Balancer)
EC2 インスタンスへのトラフィックを分散
リスナー・ターゲットグループ設定

EC2
Web アプリケーション用インスタンス
セキュリティグループで ALB からのアクセス許可

RDS (MySQL)
データベース作成
EC2 からの接続許可済み
DB ユーザーとパスワードを Terraform 変数で管理

WAF (Web Application Firewall)
ALB 配下で基本的なアクセス制御
IAMロール、ポリシー

CloudWatch
CPU アラーム作成（EC2HighCPUAlarm）
SNS 通知設定（メール認証済み）

依存関係を考慮して、VPC → ALB → EC2 → RDS → WAF → CloudWatch の順で構築。

## 動作確認項目
-- AWSマネジメントコンソール、Terraform state listコマンドで作成したリソースをチェック
<img width="622" height="622" alt="スクリーンショット 2025-09-20 220025" src="https://github.com/user-attachments/assets/103ecd86-be22-490c-98f0-c704da682b67" />



-- SSH接続でEC2ログイン
<img width="755" height="355" alt="スクリーンショット 2025-09-20 220303" src="https://github.com/user-attachments/assets/52ba6e56-b007-4098-928f-bb069ab48a0c" />


-- Mysqlインストール後、RDSに接続

-- Springbootでレイズテック学習用アプリの動作確認

<img width="1886" height="880" alt="スクリーンショット 2025-09-20 223513" src="https://github.com/user-attachments/assets/742b49c8-f7f0-4220-8e58-3ec3069612f9" />

--　ALBヘルスチェックとDNS名アクセス
<img width="918" height="839" alt="スクリーンショット 2025-09-20 223858" src="https://github.com/user-attachments/assets/6330399e-2a1d-430f-90b8-228753011a28" />

<img width="1728" height="304" alt="スクリーンショット 2025-09-20 223957" src="https://github.com/user-attachments/assets/6fb35bd9-0da6-4610-9a8b-9f5d7da4cb8d" />


-- CloudWatch＆アラーム状態確認と認証メール

<img width="613" height="271" alt="スクリーンショット 2025-09-20 215505" src="https://github.com/user-attachments/assets/1e5b6f4c-0462-46e4-98a4-2779669756eb" />

<img width="1728" height="304" alt="スクリーンショット 2025-09-20 223957" src="https://github.com/user-attachments/assets/5fd59eea-8c14-465e-b472-b618b46fadaa" />

<img width="1828" height="783" alt="スクリーンショット 2025-09-20 224141" src="https://github.com/user-attachments/assets/bfb6fa13-beaf-462e-b05f-19697ac63c69" />


--　WAFとCloudWatch連携＆ALB連携済み
<img width="1244" height="761" alt="スクリーンショット 2025-09-20 224341" src="https://github.com/user-attachments/assets/d52e8ce5-c3be-437c-ad89-0b31d477ae4c" />

<img width="1244" height="761" alt="スクリーンショット 2025-09-20 224341" src="https://github.com/user-attachments/assets/658d96b3-ed0b-43d0-b0f1-da2421251061" />


## 工夫した点・学んだこと
Terraformの.gitignore を整備して、GIthubのパブリックリモートリポジトリ（このファイル）に上げるとセキュリティー上良くないと言われるファイルを除外して、注意してコミット＆Pushした。

最初にファイルを予めTerraformモジュールを分けて、EC2 / RDS / ALB / WAF / CloudWatch など役割ごとに整理してコードを打ち込んだ。

分けたAWSリソースがあるモジュールを、ターゲット絞って一つずつAPPlyして確認した。
後々依存関係の影響で一括APPlyしないとわかりにくい箇所があったので、そこからは出来たリソースだけをまとめてAPPlyして、AWSマネジメントコンソールで確認した。

CloudFormation以上に依存関係の把握が難しく、まだ把握しきれていない部分が多々あるので、上級編前に余裕があれば後日また理解する時間を取って整理したい。